### PR TITLE
Add copycat.so single-page app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,822 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>copycat.so — Instant AI captions</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+      crossorigin
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: radial-gradient(circle at top right, #ffd7ef, #f3f5ff 40%, #ffffff 80%);
+        --surface: rgba(255, 255, 255, 0.72);
+        --surface-dark: rgba(26, 32, 44, 0.75);
+        --text: #111827;
+        --text-muted: #4b5563;
+        --accent: #7c3aed;
+        --accent-soft: rgba(124, 58, 237, 0.1);
+        --outline: rgba(124, 58, 237, 0.4);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: radial-gradient(circle at top right, #2b1838, #0f172a 45%, #020617 80%);
+          --surface: rgba(15, 23, 42, 0.8);
+          --surface-dark: rgba(2, 6, 23, 0.85);
+          --text: #e2e8f0;
+          --text-muted: #94a3b8;
+          --accent: #c084fc;
+          --accent-soft: rgba(192, 132, 252, 0.15);
+          --outline: rgba(192, 132, 252, 0.4);
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        font-family: "Space Grotesk", system-ui, -apple-system, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      main {
+        width: min(1120px, 100%);
+        display: grid;
+        gap: 1.75rem;
+        backdrop-filter: blur(20px);
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 2.5rem clamp(1.5rem, 4vw, 2.75rem);
+        background: var(--surface);
+        border-radius: 32px;
+        border: 1px solid var(--outline);
+        box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2.5rem, 5vw, 3.5rem);
+        font-weight: 700;
+        letter-spacing: -0.04em;
+      }
+
+      header p {
+        margin: 0;
+        max-width: 52ch;
+        font-size: clamp(1.1rem, 2.4vw, 1.3rem);
+        color: var(--text-muted);
+        line-height: 1.6;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .panel {
+        background: var(--surface);
+        border-radius: 28px;
+        padding: clamp(1.25rem, 3vw, 2rem);
+        border: 1px solid transparent;
+        transition: border-color 180ms ease, transform 200ms ease;
+      }
+
+      .panel:hover {
+        border-color: var(--outline);
+        transform: translateY(-4px);
+      }
+
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 220px;
+        resize: vertical;
+        padding: 1rem 1.1rem;
+        border-radius: 20px;
+        border: 2px solid transparent;
+        font: inherit;
+        line-height: 1.6;
+        background: var(--surface-dark);
+        color: var(--text);
+        box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.16);
+      }
+
+      textarea:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+
+      .controls {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .slider-group {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .slider-meta {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      input[type="range"] {
+        -webkit-appearance: none;
+        height: 6px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, var(--accent), rgba(124, 58, 237, 0.35));
+      }
+
+      input[type="range"]::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        height: 22px;
+        width: 22px;
+        border-radius: 50%;
+        background: var(--accent);
+        border: none;
+        box-shadow: 0 4px 12px rgba(124, 58, 237, 0.45);
+        cursor: pointer;
+      }
+
+      .toggles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.55rem 0.9rem;
+        border-radius: 999px;
+        background: var(--surface-dark);
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: all 140ms ease;
+        font-weight: 500;
+      }
+
+      .toggle input {
+        display: none;
+      }
+
+      .toggle.active {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+
+      .toggle .dot {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: rgba(148, 163, 184, 0.65);
+        transition: background 140ms ease;
+      }
+
+      .toggle.active .dot {
+        background: var(--accent);
+      }
+
+      .status {
+        font-size: 0.95rem;
+        color: var(--text-muted);
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+      }
+
+      .status span {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 6px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 0.8rem;
+      }
+
+      .suggestions {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .suggestion-card {
+        background: var(--surface);
+        border-radius: 24px;
+        padding: 1.25rem 1.4rem;
+        border: 1px solid transparent;
+        transition: border-color 200ms ease, transform 200ms ease;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .suggestion-card::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        border: 1px solid rgba(124, 58, 237, 0.16);
+        opacity: 0;
+        transition: opacity 200ms ease;
+        pointer-events: none;
+      }
+
+      .suggestion-card:hover {
+        transform: translateY(-3px);
+      }
+
+      .suggestion-card:hover::after {
+        opacity: 1;
+      }
+
+      .suggestion-card button {
+        position: absolute;
+        top: 14px;
+        right: 14px;
+        border: none;
+        background: rgba(255, 255, 255, 0.75);
+        color: var(--accent);
+        border-radius: 999px;
+        padding: 0.35rem 0.65rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+        cursor: pointer;
+        display: none;
+      }
+
+      .suggestion-card:hover button {
+        display: inline-flex;
+      }
+
+      .api-key {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      .api-key input {
+        flex: 1;
+        padding: 0.75rem 1rem;
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(255, 255, 255, 0.6);
+        font: inherit;
+      }
+
+      .api-key input:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+
+      .small-print {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        margin-top: 0.5rem;
+      }
+
+      .logo {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+      }
+
+      .logo span:first-child {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        border-radius: 18px;
+        background: rgba(124, 58, 237, 0.12);
+        font-weight: 700;
+        font-size: 1.15rem;
+        color: var(--accent);
+      }
+
+      .logo span:last-child {
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+      }
+
+      footer {
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+
+      footer a {
+        color: inherit;
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 2rem 1rem 3rem;
+        }
+
+        header {
+          border-radius: 24px;
+        }
+
+        .panel {
+          border-radius: 22px;
+        }
+
+        .api-key {
+          flex-direction: column;
+          align-items: stretch;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="logo">
+          <span>CC</span>
+          <span>copycat.so</span>
+        </div>
+        <h1>Clone your voice in a click.</h1>
+        <p>
+          Paste any caption, blurb, or blip and copycat.so will spawn smart AI
+          remixes instantly. Tune the vibe with sliders, toggle extra sparkle,
+          and copy the purrfect line.
+        </p>
+      </header>
+
+      <section class="panel">
+        <label for="apiKey">OpenAI API key</label>
+        <div class="api-key">
+          <input
+            type="password"
+            id="apiKey"
+            placeholder="sk-..."
+            autocomplete="off"
+          />
+          <button id="saveKey" type="button" class="toggle active">
+            <span class="dot"></span>
+            save to this browser
+          </button>
+        </div>
+        <p class="small-print">
+          Your key is stored locally in your browser only. Don't have one yet?
+          Grab an API key from <a href="https://platform.openai.com/" target="_blank" rel="noopener">OpenAI</a>.
+        </p>
+      </section>
+
+      <section class="grid">
+        <section class="panel">
+          <label for="sourceText">Drop your inspo</label>
+          <textarea
+            id="sourceText"
+            placeholder="Paste something you love, and copycat.so will craft three fresh takes..."
+          ></textarea>
+          <p class="status" id="status">
+            <span>★</span>
+            Waiting for your paste.
+          </p>
+        </section>
+
+        <section class="panel">
+          <div class="controls">
+            <div class="slider-group">
+              <label for="lengthSlider">Length</label>
+              <input type="range" id="lengthSlider" min="0" max="100" value="50" />
+              <div class="slider-meta">
+                <span>Snappy</span>
+                <span id="lengthMeta">Balanced</span>
+                <span>Storytime</span>
+              </div>
+            </div>
+
+            <div class="slider-group">
+              <label for="toneSlider">Tone</label>
+              <input type="range" id="toneSlider" min="0" max="100" value="50" />
+              <div class="slider-meta">
+                <span>Corporate</span>
+                <span id="toneMeta">Just right</span>
+                <span>Playful</span>
+              </div>
+            </div>
+
+            <div class="slider-group">
+              <label for="riskSlider">Spice level</label>
+              <input type="range" id="riskSlider" min="0" max="100" value="35" />
+              <div class="slider-meta">
+                <span>Tame</span>
+                <span id="riskMeta">Cheeky</span>
+                <span>Chaotic</span>
+              </div>
+            </div>
+
+            <div>
+              <span style="font-weight: 600; display: block; margin-bottom: 0.5rem"
+                >Extras</span
+              >
+              <div class="toggles" id="extraToggles"></div>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <section class="panel">
+        <div class="status" id="suggestionStatus">
+          <span>…</span>
+          No clones yet.
+        </div>
+        <div class="suggestions" id="suggestions"></div>
+      </section>
+
+      <footer>
+        Crafted with ☕ + 🐾 by copycat.so. Open-source and ready for remix.
+      </footer>
+    </main>
+
+    <template id="suggestionTemplate">
+      <article class="suggestion-card">
+        <button type="button">copy</button>
+        <p></p>
+      </article>
+    </template>
+
+    <script>
+      const state = {
+        length: 0.5,
+        tone: 0.5,
+        risk: 0.35,
+        extras: new Set(),
+        lastText: "",
+        lastCallId: 0,
+        controller: null,
+      };
+
+      const extraOptions = [
+        { id: "emoji", label: "Use emojis" },
+        { id: "cta", label: "Punchy CTA" },
+        { id: "question", label: "End with a question" },
+        { id: "hashtags", label: "Hashtag sprinkle" },
+      ];
+
+      const apiKeyInput = document.getElementById("apiKey");
+      const saveKeyButton = document.getElementById("saveKey");
+      const sourceText = document.getElementById("sourceText");
+      const status = document.getElementById("status");
+      const suggestionStatus = document.getElementById("suggestionStatus");
+      const suggestions = document.getElementById("suggestions");
+
+      const lengthSlider = document.getElementById("lengthSlider");
+      const toneSlider = document.getElementById("toneSlider");
+      const riskSlider = document.getElementById("riskSlider");
+
+      const lengthMeta = document.getElementById("lengthMeta");
+      const toneMeta = document.getElementById("toneMeta");
+      const riskMeta = document.getElementById("riskMeta");
+
+      const toggleContainer = document.getElementById("extraToggles");
+      const suggestionTemplate = document.getElementById("suggestionTemplate");
+
+      const sliderMetaText = (value, map) => {
+        if (value < 0.2) return map[0];
+        if (value < 0.4) return map[1];
+        if (value < 0.6) return map[2];
+        if (value < 0.8) return map[3];
+        return map[4];
+      };
+
+      const sliderLabels = {
+        length: ["Micro", "Snack", "Balanced", "Detailed", "Essay"],
+        tone: ["Poker face", "Polite", "Just right", "Friendly", "Feral"],
+        risk: ["Safe", "Spicy", "Cheeky", "Bold", "Unhinged"],
+      };
+
+      const fakeBanks = [
+        "Spark curiosity with a hook, a playful tone, and a clever CTA.",
+        "Highlight the benefit in the first sentence, then invite the reader to act.",
+        "Lean into storytelling — paint a vivid picture before the punchline.",
+        "Channel high-energy hype with emoji accents and upbeat verbs.",
+        "Keep it crisp, witty, and memorable with a single bold idea.",
+      ];
+
+      function populateToggles() {
+        extraOptions.forEach((option) => {
+          const toggle = document.createElement("button");
+          toggle.type = "button";
+          toggle.className = "toggle";
+          toggle.innerHTML = `<span class="dot"></span>${option.label}`;
+          toggle.addEventListener("click", () => {
+            if (state.extras.has(option.id)) {
+              state.extras.delete(option.id);
+              toggle.classList.remove("active");
+            } else {
+              state.extras.add(option.id);
+              toggle.classList.add("active");
+            }
+            scheduleGeneration();
+          });
+          toggleContainer.appendChild(toggle);
+        });
+      }
+
+      function loadStoredKey() {
+        const stored = localStorage.getItem("copycat-openai-key");
+        if (stored) {
+          apiKeyInput.value = stored;
+          saveKeyButton.classList.add("active");
+          saveKeyButton.querySelector(".dot").style.background = "var(--accent)";
+        }
+      }
+
+      function toggleKeyStorage() {
+        if (saveKeyButton.classList.contains("active")) {
+          saveKeyButton.classList.remove("active");
+          localStorage.removeItem("copycat-openai-key");
+          saveKeyButton.querySelector(".dot").style.background = "";
+        } else {
+          saveKeyButton.classList.add("active");
+          localStorage.setItem("copycat-openai-key", apiKeyInput.value.trim());
+          saveKeyButton.querySelector(".dot").style.background = "var(--accent)";
+        }
+      }
+
+      function getApiKey() {
+        const key = apiKeyInput.value.trim();
+        if (!key) {
+          suggestionStatus.innerHTML = "<span>!</span> Add your API key to generate real clones.";
+        }
+        return key;
+      }
+
+      function updateSliderState() {
+        state.length = Number(lengthSlider.value) / 100;
+        state.tone = Number(toneSlider.value) / 100;
+        state.risk = Number(riskSlider.value) / 100;
+
+        lengthMeta.textContent = sliderMetaText(state.length, sliderLabels.length);
+        toneMeta.textContent = sliderMetaText(state.tone, sliderLabels.tone);
+        riskMeta.textContent = sliderMetaText(state.risk, sliderLabels.risk);
+      }
+
+      function copyText(text, node) {
+        navigator.clipboard.writeText(text).then(() => {
+          const original = node.textContent;
+          node.textContent = "copied!";
+          setTimeout(() => (node.textContent = "copy"), 1200);
+        });
+      }
+
+      function renderSuggestions(list) {
+        suggestions.innerHTML = "";
+        if (!list.length) {
+          suggestionStatus.innerHTML = "<span>…</span> No clones yet.";
+          return;
+        }
+
+        suggestionStatus.innerHTML = `<span>✨</span> ${list.length} clones ready.`;
+
+        list.forEach((text, index) => {
+          const node = suggestionTemplate.content.cloneNode(true);
+          const card = node.querySelector(".suggestion-card");
+          card.style.setProperty("--card-index", index);
+          const p = node.querySelector("p");
+          p.textContent = text;
+          const button = node.querySelector("button");
+          button.addEventListener("click", () => copyText(text, button));
+          suggestions.appendChild(node);
+        });
+      }
+
+      function fakeSuggestions(text) {
+        if (!text) {
+          renderSuggestions([]);
+          return;
+        }
+        const tone = sliderMetaText(state.tone, sliderLabels.tone);
+        const spice = sliderMetaText(state.risk, sliderLabels.risk);
+        const length = sliderMetaText(state.length, sliderLabels.length);
+        const extras = [...state.extras].map((id) =>
+          extraOptions.find((opt) => opt.id === id)?.label.toLowerCase()
+        );
+        const prompt = `${tone} • ${spice} • ${length}`;
+        const base = `(${prompt}) ${fakeBanks[Math.floor(Math.random() * fakeBanks.length)]}`;
+        const extraTail = extras.length ? ` + ${extras.join(" + ")}` : "";
+        renderSuggestions([
+          `${base}${extraTail} → ${text.slice(0, 40)}...`,
+          `${base}${extraTail} ⇢ Remix the hook and end bold.`,
+          `${base}${extraTail} ⇢ Spotlight the benefit, then wink.`,
+        ]);
+      }
+
+      async function callOpenAI(text, callId) {
+        const key = getApiKey();
+        if (!key) {
+          fakeSuggestions(text);
+          return;
+        }
+
+        if (state.controller) {
+          state.controller.abort();
+        }
+        const controller = new AbortController();
+        state.controller = controller;
+
+        const vibeDescription = [
+          `Length: ${sliderMetaText(state.length, sliderLabels.length)} (${Math.round(
+            state.length * 100
+          )}%)`,
+          `Tone: ${sliderMetaText(state.tone, sliderLabels.tone)} (${Math.round(
+            state.tone * 100
+          )}%)`,
+          `Risk: ${sliderMetaText(state.risk, sliderLabels.risk)} (${Math.round(
+            state.risk * 100
+          )}%)`,
+        ];
+
+        if (state.extras.size) {
+          vibeDescription.push(
+            `Extras: ${[...state.extras]
+              .map((id) => extraOptions.find((opt) => opt.id === id)?.label)
+              .join(", ")}`
+          );
+        }
+
+        status.innerHTML = "<span>⏳</span> Summoning clones...";
+        suggestionStatus.innerHTML = "<span>…</span> Thinking...";
+
+        try {
+          const response = await fetch("https://api.openai.com/v1/responses", {
+            method: "POST",
+            signal: controller.signal,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${key}`,
+            },
+            body: JSON.stringify({
+              model: "gpt-4.1-mini",
+              input: [
+                {
+                  role: "system",
+                  content: [
+                    {
+                      type: "text",
+                      text:
+                        "You are copycat.so, an elite social copy remixer. Provide exactly three numbered variations, each punchy and under 280 characters unless a longer length is requested. Keep formatting clean for direct copying.",
+                    },
+                  ],
+                },
+                {
+                  role: "user",
+                  content: [
+                    {
+                      type: "text",
+                      text: `Original text:\n${text}\n\nDesired vibe:\n${vibeDescription.join("\n")}\n\nReturn three distinct options.`,
+                    },
+                  ],
+                },
+              ],
+            }),
+          });
+
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+
+          const data = await response.json();
+          if (callId !== state.lastCallId) {
+            return; // stale response
+          }
+
+          const output = data.output || data.responses || [];
+          let textOutput = [];
+          if (typeof data.output_text === "string") {
+            textOutput = data.output_text.split(/\n(?:\d+\.|-)/).map((s) => s.trim()).filter(Boolean);
+          } else if (Array.isArray(output)) {
+            textOutput = output
+              .flatMap((item) => item.content || [])
+              .map((chunk) => chunk.text)
+              .join("\n")
+              .split(/\n\s*\d+\.\s*/)
+              .map((line) => line.trim())
+              .filter(Boolean);
+          }
+
+          if (!textOutput.length && data.content) {
+            textOutput = data.content
+              .map((item) => item.text)
+              .join("\n")
+              .split(/\n\s*\d+\.\s*/)
+              .map((line) => line.trim())
+              .filter(Boolean);
+          }
+
+          if (!textOutput.length) {
+            textOutput = ["Could not parse AI response. Check the console for details."];
+            console.error("Unexpected response shape", data);
+          }
+
+          renderSuggestions(textOutput.slice(0, 3));
+          status.innerHTML = "<span>✅</span> Clone complete.";
+        } catch (error) {
+          if (error.name === "AbortError") {
+            return;
+          }
+          console.error(error);
+          suggestionStatus.innerHTML = "<span>!</span> Oops — something glitched.";
+          status.innerHTML = "<span>⚠️</span> Check the console & API key.";
+          fakeSuggestions(text);
+        }
+      }
+
+      function scheduleGeneration() {
+        const text = sourceText.value.trim();
+        if (!text) {
+          state.lastText = "";
+          status.innerHTML = "<span>★</span> Waiting for your paste.";
+          renderSuggestions([]);
+          return;
+        }
+
+        if (text === state.lastText) {
+          return;
+        }
+
+        state.lastText = text;
+        state.lastCallId += 1;
+        const callId = state.lastCallId;
+
+        if (state.debounce) {
+          clearTimeout(state.debounce);
+        }
+
+        state.debounce = setTimeout(() => callOpenAI(text, callId), 500);
+        status.innerHTML = "<span>🐾</span> Prepping the clones...";
+      }
+
+      [lengthSlider, toneSlider, riskSlider].forEach((slider) =>
+        slider.addEventListener("input", () => {
+          updateSliderState();
+          scheduleGeneration();
+        })
+      );
+
+      sourceText.addEventListener("input", scheduleGeneration);
+      sourceText.addEventListener("paste", () => {
+        setTimeout(scheduleGeneration, 50);
+      });
+
+      apiKeyInput.addEventListener("change", () => {
+        if (saveKeyButton.classList.contains("active")) {
+          localStorage.setItem("copycat-openai-key", apiKeyInput.value.trim());
+        }
+        scheduleGeneration();
+      });
+
+      saveKeyButton.addEventListener("click", toggleKeyStorage);
+
+      populateToggles();
+      updateSliderState();
+      loadStoredKey();
+      fakeSuggestions("");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a single-page copycat.so experience with a stylized layout ready for GitHub Pages
- implement controls for length, tone, spice, and extra toggles that trigger automatic remixing
- integrate OpenAI Responses API calls with local fallback suggestions and clipboard copy helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d589c4a9fc83279cd7af2272c3334b