### PR TITLE
Add responses beta header to OpenAI fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,6 +689,7 @@
             signal: controller.signal,
             headers: {
               "Content-Type": "application/json",
+              "OpenAI-Beta": "responses=v1",
               Authorization: `Bearer ${key}`,
             },
             body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add the `OpenAI-Beta: responses=v1` header to the Responses API request so it is accepted

## Testing
- no tests were run (not needed)


------
https://chatgpt.com/codex/tasks/task_b_68d58ea791a08327890dcda1a043d325